### PR TITLE
Fix start game throttle control

### DIFF
--- a/src/js/GameEngine.js
+++ b/src/js/GameEngine.js
@@ -71,11 +71,13 @@ class GameEngine {
     
     startGame() {
         if (this.gameStarted) return;
-        
+
+        this.stop();
+        this.isAutoplay = false;
         this.gameStarted = true;
         document.getElementById('startScreen').classList.add('hidden');
         document.getElementById('stats').classList.remove('hidden');
-        
+
         this.audioManager.init();
         this.setupRace();
         this.start();


### PR DESCRIPTION
## Summary
- stop autoplay when player starts the game
- disable autoplay flag so user controls work

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a6f4dbf4883238259bd0ac4ea6369