### PR TITLE
Use GameEngine in CLI

### DIFF
--- a/src/training/cli.js
+++ b/src/training/cli.js
@@ -23,6 +23,8 @@ if (typeof global.document === 'undefined') {
     global.document = {
         addEventListener: () => {},
         getElementById: () => ({
+            addEventListener: () => {},
+            removeEventListener: () => {},
             getContext: () => ({}),
             classList: { add: () => {}, remove: () => {} },
             textContent: ''
@@ -410,4 +412,4 @@ if (require.main === module) {
     main();
 }
 
-module.exports = { TrainingEnvironment };
+module.exports = { TrainingEnvironment }

--- a/src/training/cli.js
+++ b/src/training/cli.js
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
 
-const fs = require('fs');
-const path = require('path');
-const { NeuralNetwork } = require('../js/NeuralNetwork');
-const { Kart } = require('../js/Kart')
-const { GameEngine } = require('../js/GameEngine')
-const DEBUG_Cli = false;
+const fs = require('fs')
+const path = require('path')
 
 const THREE = require('three')
 global.THREE = THREE
+
+const { NeuralNetwork } = require('../js/NeuralNetwork')
+const { Kart } = require('../js/Kart')
+const { GameEngine } = require('../js/GameEngine')
+const DEBUG_Cli = false
 
 if (typeof global.window === 'undefined') {
     global.window = {
@@ -20,7 +21,12 @@ if (typeof global.window === 'undefined') {
 
 if (typeof global.document === 'undefined') {
     global.document = {
-        getElementById: () => ({ getContext: () => ({}) })
+        addEventListener: () => {},
+        getElementById: () => ({
+            getContext: () => ({}),
+            classList: { add: () => {}, remove: () => {} },
+            textContent: ''
+        })
     }
 }
 

--- a/src/training/cli.js
+++ b/src/training/cli.js
@@ -23,6 +23,13 @@ if (typeof window === 'undefined') {
     }
 }
 
+if (typeof global.AudioManager === 'undefined') {
+    global.AudioManager = class {
+        async init() {}
+        resume() {}
+    }
+}
+
 const { NeuralNetwork } = require('../js/NeuralNetwork')
 const { Kart } = require('../js/Kart')
 const { GameEngine } = require('../js/GameEngine')

--- a/src/training/cli.js
+++ b/src/training/cli.js
@@ -4,10 +4,25 @@ const fs = require('fs');
 const path = require('path');
 const { NeuralNetwork } = require('../js/NeuralNetwork');
 const { Kart } = require('../js/Kart')
+const { GameEngine } = require('../js/GameEngine')
 const DEBUG_Cli = false;
 
 const THREE = require('three')
 global.THREE = THREE
+
+if (typeof global.window === 'undefined') {
+    global.window = {
+        innerWidth: 800,
+        innerHeight: 600,
+        addEventListener: () => {}
+    }
+}
+
+if (typeof global.document === 'undefined') {
+    global.document = {
+        getElementById: () => ({ getContext: () => ({}) })
+    }
+}
 
 class TrainingEnvironment {
     constructor(trackType) {
@@ -16,7 +31,9 @@ class TrainingEnvironment {
         this.generations = parseInt(process.argv[2]) || 50;
         this.mutationRate = 0.1;
         this.eliteCount = 5;
-        
+
+        this.gameEngine = new GameEngine()
+
         this.population = [];
         this.generation = 0;
         this.bestFitness = 0;

--- a/src/training/cli.js
+++ b/src/training/cli.js
@@ -6,6 +6,23 @@ const path = require('path')
 const THREE = require('three')
 global.THREE = THREE
 
+// In a Node environment Three.js cannot create a real WebGL context.
+// Provide a minimal renderer so GameEngine can be instantiated during training.
+if (typeof window === 'undefined') {
+    THREE.WebGLRenderer = class {
+        constructor() {
+            this.domElement = {
+                addEventListener: () => {},
+                removeEventListener: () => {}
+            }
+            this.shadowMap = {}
+        }
+        setSize() {}
+        setClearColor() {}
+        render() {}
+    }
+}
+
 const { NeuralNetwork } = require('../js/NeuralNetwork')
 const { Kart } = require('../js/Kart')
 const { GameEngine } = require('../js/GameEngine')


### PR DESCRIPTION
## Summary
- import `GameEngine` into `src/training/cli.js`
- set up simple window and document stubs for Node
- instantiate `GameEngine` inside `TrainingEnvironment`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ac44dbb188323994b989037f7bc41