### PR TITLE
Improve circuit track layout

### DIFF
--- a/src/tracks/circuit.json
+++ b/src/tracks/circuit.json
@@ -1,7 +1,7 @@
 {
   "name": "Circuit Track",
   "type": "circuit",
-  "description": "A classic racing circuit with smooth asphalt and red barriers",
+  "description": "A classic circular circuit with smooth asphalt, red barriers, and numerous checkpoints",
   "difficulty": "medium",
   "lapCount": 3,
   "startPositions": [
@@ -12,9 +12,13 @@
   ],
   "checkpoints": [
     { "x": 0, "y": 0, "z": -40, "radius": 5 },
+    { "x": 28.28, "y": 0, "z": -28.28, "radius": 5 },
     { "x": 40, "y": 0, "z": 0, "radius": 5 },
+    { "x": 28.28, "y": 0, "z": 28.28, "radius": 5 },
     { "x": 0, "y": 0, "z": 40, "radius": 5 },
-    { "x": -40, "y": 0, "z": 0, "radius": 5 }
+    { "x": -28.28, "y": 0, "z": 28.28, "radius": 5 },
+    { "x": -40, "y": 0, "z": 0, "radius": 5 },
+    { "x": -28.28, "y": 0, "z": -28.28, "radius": 5 }
   ],
   "powerupSpawns": [
     { "x": 20, "y": 1, "z": 20, "type": "random" },


### PR DESCRIPTION
## Summary
- make the circuit layout circular with eight checkpoints
- restore original Kart test expectation

## Testing
- `npm test` *(fails: Kart maxSpeed expectation mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_687ad7c9f84c8323a8df0f2dcfc8fa06