### PR TITLE
Handle obstacle collisions during CLI training

### DIFF
--- a/src/js/Track.js
+++ b/src/js/Track.js
@@ -131,9 +131,12 @@ class Track {
 
     checkObstacleCollisions(kart) {
         const kartBox = new THREE.Box3().setFromObject(kart)
+        let collided = false
+
         this.obstacles.forEach(obstacle => {
             const obstacleBox = new THREE.Box3().setFromObject(obstacle)
             if (kartBox.intersectsBox(obstacleBox)) {
+                collided = true
                 const obstacleCenter = new THREE.Vector3()
                 obstacleBox.getCenter(obstacleCenter)
 
@@ -149,6 +152,8 @@ class Track {
                 kart.velocity.sub(velocityAlongNormal).multiplyScalar(0.8)
             }
         })
+
+        return collided
     }
 }
 


### PR DESCRIPTION
## Summary
- mark karts as disqualified if they hit obstacles during CLI training
- end generation early when entire population is disqualified
- return collision info from Track.checkObstacleCollisions
- adjust population loop to skip to next generation when all karts fail

## Testing
- `npm run train 1`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ae24ddc688323ae510155366d02b6