### PR TITLE
Fix missile movement

### DIFF
--- a/src/js/Kart.js
+++ b/src/js/Kart.js
@@ -206,14 +206,20 @@ class Kart extends THREE.Group {
     
     fireMissile() {
         if (DEBUG_Kart) console.log('Kart: Firing missile.');
-        const missile = new Missile(this.position.clone(), this.rotation.y, this.scene);
-        missile.owner = this;
+        const missile = new Missile(this.position.clone(), this.rotation.y, this.scene)
+        missile.owner = this
+        if (this.currentTrack && this.currentTrack.missiles) {
+            this.currentTrack.missiles.push(missile)
+        }
     }
-    
+
     dropMine() {
         if (DEBUG_Kart) console.log('Kart: Dropping mine.');
-        const mine = new Mine(this.position.clone(), this.scene);
-        mine.owner = this;
+        const mine = new Mine(this.position.clone(), this.scene)
+        mine.owner = this
+        if (this.currentTrack && this.currentTrack.mines) {
+            this.currentTrack.mines.push(mine)
+        }
     }
     
     collectPowerup(type) {

--- a/src/js/Powerup.js
+++ b/src/js/Powerup.js
@@ -197,5 +197,5 @@ class Mine {
 }
 
 if (typeof module !== "undefined") {
-    module.exports = { Powerup }
+    module.exports = { Powerup, Missile, Mine }
 }

--- a/src/js/Track.js
+++ b/src/js/Track.js
@@ -8,6 +8,8 @@ class Track {
         this.checkpoints = [];
         this.obstacles = [];
         this.powerups = [];
+        this.missiles = [];
+        this.mines = [];
         this.startPositions = [];
         this.trackData = null;
     }
@@ -117,8 +119,18 @@ class Track {
     
     update(deltaTime) {
         this.powerups.forEach(powerup => {
-            powerup.update(deltaTime);
-        });
+            powerup.update(deltaTime)
+        })
+
+        this.missiles.forEach(missile => {
+            missile.update(deltaTime)
+        })
+        this.missiles = this.missiles.filter(missile => missile.active)
+
+        this.mines.forEach(mine => {
+            mine.update(deltaTime)
+        })
+        this.mines = this.mines.filter(mine => mine.active)
     }
     
     checkPowerupCollisions(kart) {

--- a/tests/Missile.test.js
+++ b/tests/Missile.test.js
@@ -1,0 +1,12 @@
+const { Track } = require('../src/js/Track');
+
+describe('Missile integration', () => {
+    test('track update should advance missiles', () => {
+        const scene = { add: jest.fn(), remove: jest.fn() };
+        const track = new Track('test', scene);
+        const missile = { update: jest.fn(), active: true };
+        track.missiles.push(missile);
+        track.update(0.1);
+        expect(missile.update).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
- store missiles and mines on each track
- update projectile positions every frame
- attach missiles and mines to the active track when fired
- export Missile and Mine for tests
- add regression test ensuring missiles are updated

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ae2deea4c8323bb10935246734ef4