### PR TITLE
Flip circuit track colors

### DIFF
--- a/src/js/Track.js
+++ b/src/js/Track.js
@@ -69,6 +69,9 @@ class Track {
     
     createCheckpoints() {
         if (DEBUG_Track) console.log('Track: Creating checkpoints.');
+        const checkpointColor = this.trackData.environment.checkpointColor
+            ? parseInt(this.trackData.environment.checkpointColor)
+            : 0x00ff00
         this.trackData.checkpoints.forEach((cp, index) => {
             const checkpoint = {
                 position: new THREE.Vector3(cp.x, cp.y, cp.z),
@@ -79,9 +82,6 @@ class Track {
             this.checkpoints.push(checkpoint);
             if (typeof global === 'undefined' || !global.NO_GRAPHICS) {
                 const geometry = new THREE.RingGeometry(cp.radius - 1, cp.radius, 16);
-                const checkpointColor = this.trackData.environment.checkpointColor
-                    ? parseInt(this.trackData.environment.checkpointColor)
-                    : 0x00ff00
                 const material = new THREE.MeshBasicMaterial({
                     color: checkpointColor,
                     transparent: true,

--- a/src/js/Track.js
+++ b/src/js/Track.js
@@ -79,8 +79,11 @@ class Track {
             this.checkpoints.push(checkpoint);
             if (typeof global === 'undefined' || !global.NO_GRAPHICS) {
                 const geometry = new THREE.RingGeometry(cp.radius - 1, cp.radius, 16);
+                const checkpointColor = this.trackData.environment.checkpointColor
+                    ? parseInt(this.trackData.environment.checkpointColor)
+                    : 0x00ff00
                 const material = new THREE.MeshBasicMaterial({
-                    color: 0x00ff00,
+                    color: checkpointColor,
                     transparent: true,
                     opacity: 0.5,
                     side: THREE.DoubleSide

--- a/src/tracks/circuit.json
+++ b/src/tracks/circuit.json
@@ -28,7 +28,8 @@
   ],
   "environment": {
     "skyColor": "0x87CEEB",
-    "groundColor": "0x444444",
+    "groundColor": "0x00ff00",
+    "checkpointColor": "0x444444",
     "ambientLight": "0x404040",
     "directionalLight": "0xffffff"
   },


### PR DESCRIPTION
## Summary
- make track checkpoint ring color configurable
- swap circuit track ground and checkpoint colors to flip green and grey

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ae8cfadcc8323bbbfe172ab498bac