### PR TITLE
Add checkpoint marker

### DIFF
--- a/tests/GameEngine.test.js
+++ b/tests/GameEngine.test.js
@@ -1,0 +1,38 @@
+global.AudioManager = class AudioManager {}
+global.THREE.Scene = class Scene { add() {} }
+global.THREE.AmbientLight = class AmbientLight {}
+global.THREE.DirectionalLight = class DirectionalLight {
+    constructor() {
+        this.position = { set: () => {} }
+        this.castShadow = false
+        this.shadow = { mapSize: {}, camera: {} }
+    }
+}
+global.THREE.WebGLRenderer = class WebGLRenderer {
+    constructor() { this.shadowMap = {} }
+    setSize() {}
+    setClearColor() {}
+    set sortObjects(value) {}
+}
+global.THREE.PCFSoftShadowMap = 0
+const { GameEngine } = require('../src/js/GameEngine')
+
+describe('GameEngine checkpoint marker', () => {
+    test('updateCheckpointMarker positions marker over next checkpoint', () => {
+        const engine = new GameEngine()
+        engine.currentTrack = {
+            checkpoints: [
+                { position: new THREE.Vector3(0, 0, 0) },
+                { position: new THREE.Vector3(5, 0, 0) }
+            ]
+        }
+        engine.karts = [{ isPlayer: true, nextCheckpoint: 1 }]
+        engine.checkpointMarker = { position: new THREE.Vector3() }
+        engine.checkpointMarker.position.copy = function(vec) { this.set(vec.x, vec.y, vec.z); return this }
+
+        engine.updateCheckpointMarker()
+        expect(engine.checkpointMarker.position.x).toBe(5)
+        expect(engine.checkpointMarker.position.y).toBe(2)
+        expect(engine.checkpointMarker.position.z).toBe(0)
+    })
+})


### PR DESCRIPTION
## Summary
- highlight player's next checkpoint with a red sphere
- keep marker updated each frame
- test checkpoint marker behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ae97833248323b8e424c629cc4823