### PR TITLE
Implement hit effects and mine delay

### DIFF
--- a/src/js/Kart.js
+++ b/src/js/Kart.js
@@ -307,6 +307,15 @@ class Kart extends THREE.Group {
         right.applyQuaternion(this.quaternion);
         return right;
     }
+
+    applyHit(duration) {
+        if (DEBUG_Kart) console.log(`Kart: Hit for ${duration}s`)
+        this.velocity.set(0, 0, 0)
+        this.isStopped = true
+        this.stopTime = duration
+        this.isInvulnerable = true
+        this.invulnerabilityTime = duration
+    }
 }
 
 if (typeof module !== "undefined") {

--- a/src/js/Powerup.js
+++ b/src/js/Powerup.js
@@ -121,10 +121,12 @@ class Missile {
     
     checkCollisions() {
         const karts = window.gameEngine ? window.gameEngine.karts : [];
-        
+
         karts.forEach(kart => {
             if (kart !== this.owner && kart.position.distanceTo(this.position) < 2) {
-                kart.handleCollision();
+                if (typeof kart.applyHit === 'function') {
+                    kart.applyHit(5);
+                }
                 this.destroy();
             }
         });
@@ -142,6 +144,7 @@ class Mine {
         this.scene = scene;
         this.owner = null;
         this.active = true;
+        this.activationDelay = 1;
         this.lifetime = 30;
         if (!(typeof global !== 'undefined' && global.NO_GRAPHICS)) {
             this.createMesh();
@@ -169,7 +172,11 @@ class Mine {
     
     update(deltaTime) {
         if (!this.active) return;
-        
+
+        if (this.activationDelay > 0) {
+            this.activationDelay -= deltaTime;
+        }
+
         this.lifetime -= deltaTime;
         if (this.lifetime <= 0) {
             this.destroy();
@@ -182,11 +189,15 @@ class Mine {
     }
     
     checkCollisions() {
+        if (this.activationDelay > 0) return;
+
         const karts = window.gameEngine ? window.gameEngine.karts : [];
-        
+
         karts.forEach(kart => {
             if (kart !== this.owner && kart.position.distanceTo(this.position) < 1.5) {
-                kart.handleCollision();
+                if (typeof kart.applyHit === 'function') {
+                    kart.applyHit(5);
+                }
                 this.destroy();
             }
         });

--- a/tests/Hit.test.js
+++ b/tests/Hit.test.js
@@ -1,0 +1,54 @@
+const { Kart } = require('../src/js/Kart');
+const { Mine, Missile } = require('../src/js/Powerup');
+
+describe('Kart hit mechanics', () => {
+    test('applyHit stops kart and grants invulnerability', () => {
+        const scene = { add: jest.fn(), remove: jest.fn() }
+        const kart = new Kart(0xff0000, scene)
+        kart.velocity.set(5, 0, 3)
+
+        kart.applyHit(5)
+
+        expect(kart.isStopped).toBe(true)
+        expect(kart.stopTime).toBe(5)
+        expect(kart.isInvulnerable).toBe(true)
+        expect(kart.invulnerabilityTime).toBe(5)
+        expect(kart.velocity.x).toBe(0)
+        expect(kart.velocity.y).toBe(0)
+        expect(kart.velocity.z).toBe(0)
+    })
+})
+
+describe('Mine activation', () => {
+    test('mine only triggers after activation delay', () => {
+        const scene = { add: jest.fn(), remove: jest.fn() }
+        const mine = new Mine(new THREE.Vector3(0,0,0), scene)
+        const kart = new Kart(0xff0000, scene)
+        kart.position.set(0,0,0)
+        window.gameEngine = { karts: [kart] }
+
+        mine.update(0.5)
+        expect(kart.isInvulnerable).toBe(false)
+        expect(mine.active).toBe(true)
+
+        mine.update(0.6)
+        expect(kart.isInvulnerable).toBe(true)
+        expect(mine.active).toBe(false)
+    })
+})
+
+describe('Missile collision', () => {
+    test('missile collision stops kart', () => {
+        const scene = { add: jest.fn(), remove: jest.fn() }
+        const missile = new Missile(new THREE.Vector3(0,0,0), 0, scene)
+        const kart = new Kart(0xff0000, scene)
+        kart.position.set(0,0,0)
+        missile.owner = {}
+        window.gameEngine = { karts: [kart] }
+
+        missile.checkCollisions()
+
+        expect(kart.isInvulnerable).toBe(true)
+        expect(missile.active).toBe(false)
+    })
+})

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -16,6 +16,9 @@ global.THREE = {
             return this
         }
         clone() { return new Vector3(this.x, this.y, this.z); }
+        copy(v) {
+            this.x = v.x; this.y = v.y; this.z = v.z; return this
+        }
         add(v) { return this; }
         multiplyScalar(s) { return this; }
         distanceTo(v) { return Math.sqrt((this.x - v.x) ** 2 + (this.y - v.y) ** 2 + (this.z - v.z) ** 2); }


### PR DESCRIPTION
## Summary
- add `applyHit` to Kart to stop and protect karts
- trigger `applyHit` when missiles or mines collide
- give mines a 1s activation delay
- expand Vector3 stub to support `.copy`
- add tests for hit behavior, mine delay and missile collisions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687af06786808323881b5b43f2aafa33