### PR TITLE
Reverse steering logic

### DIFF
--- a/src/js/Kart.js
+++ b/src/js/Kart.js
@@ -143,13 +143,15 @@ class Kart extends THREE.Group {
     
     applyForce(acceleration, turning) {
         if (DEBUG_Kart) console.log(`Kart: Applying force - acceleration: ${acceleration}, turning: ${turning}`);
-        const forward = new THREE.Vector3(0, 0, -1);
-        forward.applyQuaternion(this.quaternion);
-        
-        this.acceleration.add(forward.multiplyScalar(acceleration));
-        const minTurnSpeed = 0.1; // Minimum speed to allow turning
+        const forward = new THREE.Vector3(0, 0, -1)
+        forward.applyQuaternion(this.quaternion)
+
+        const movingBackward = this.velocity.dot(forward) < 0
+        this.acceleration.add(forward.clone().multiplyScalar(acceleration))
+        const turnDirection = movingBackward ? -turning : turning
+        const minTurnSpeed = 0.1 // Minimum speed to allow turning
         if (this.velocity.length() > minTurnSpeed) {
-            this.angularVelocity += turning * (this.velocity.length() / this.maxSpeed);
+            this.angularVelocity += turnDirection * (this.velocity.length() / this.maxSpeed)
         }
     }
     

--- a/tests/Kart.test.js
+++ b/tests/Kart.test.js
@@ -54,6 +54,13 @@ describe('Kart', () => {
         kart.updateProgress()
         expect(kart.progress).toBe(0.5)
     })
+
+    test('reverses steering when moving backward', () => {
+        kart.velocity.set(0, 0, 1)
+        kart.angularVelocity = 0
+        kart.applyForce(0, kart.turnSpeed)
+        expect(kart.angularVelocity).toBeLessThan(0)
+    })
 })
 
 describe('NeuralNetwork', () => {


### PR DESCRIPTION
## Summary
- reverse steering direction when a kart is moving backwards
- add unit test covering backward steering behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b452f84088323ae821a0f6b6aa3ce