### PR TITLE
Stop kart and grant invulnerability on projectile hit

### DIFF
--- a/src/js/GameEngine.js
+++ b/src/js/GameEngine.js
@@ -26,7 +26,11 @@ class GameEngine {
         }
 
         this.checkpointMarker = null
-        
+
+        if (typeof window !== 'undefined') {
+            window.gameEngine = this
+        }
+
         this.setupRenderer();
         this.setupLighting();
         this.setupControls();

--- a/src/js/Kart.js
+++ b/src/js/Kart.js
@@ -221,6 +221,17 @@ class Kart extends THREE.Group {
             this.currentTrack.mines.push(mine)
         }
     }
+
+    applyProjectileHit() {
+        if (this.isInvulnerable) return
+        this.velocity.set(0, 0, 0)
+        this.acceleration.set(0, 0, 0)
+        this.isInvulnerable = true
+        this.invulnerabilityTime = 3
+        if (typeof global === 'undefined' || !global.NO_GRAPHICS) {
+            this.body.material.opacity = 0.7
+        }
+    }
     
     collectPowerup(type) {
         if (DEBUG_Kart) console.log(`Kart: Collecting powerup of type ${type}`);

--- a/src/js/Powerup.js
+++ b/src/js/Powerup.js
@@ -124,7 +124,9 @@ class Missile {
         
         karts.forEach(kart => {
             if (kart !== this.owner && kart.position.distanceTo(this.position) < 2) {
-                kart.handleCollision();
+                if (typeof kart.applyProjectileHit === 'function') {
+                    kart.applyProjectileHit();
+                }
                 this.destroy();
             }
         });
@@ -186,7 +188,9 @@ class Mine {
         
         karts.forEach(kart => {
             if (kart !== this.owner && kart.position.distanceTo(this.position) < 1.5) {
-                kart.handleCollision();
+                if (typeof kart.applyProjectileHit === 'function') {
+                    kart.applyProjectileHit();
+                }
                 this.destroy();
             }
         });

--- a/tests/Missile.test.js
+++ b/tests/Missile.test.js
@@ -1,4 +1,6 @@
 const { Track } = require('../src/js/Track');
+const { Kart } = require('../src/js/Kart');
+const { Missile, Mine } = require('../src/js/Powerup');
 
 describe('Missile integration', () => {
     test('track update should advance missiles', () => {
@@ -8,5 +10,33 @@ describe('Missile integration', () => {
         track.missiles.push(missile);
         track.update(0.1);
         expect(missile.update).toHaveBeenCalled();
+    });
+});
+
+describe('Projectile hits', () => {
+    test('missile hit stops kart and grants invulnerability', () => {
+        const scene = { add: jest.fn(), remove: jest.fn() };
+        const kart = new Kart(0xff0000, scene);
+        window.gameEngine = { karts: [kart] };
+        const missile = new Missile(kart.position.clone(), 0, scene);
+        missile.owner = {};
+        missile.checkCollisions();
+        expect(kart.isInvulnerable).toBe(true);
+        expect(kart.invulnerabilityTime).toBe(3);
+        expect(kart.velocity.length()).toBe(0);
+        expect(missile.active).toBe(false);
+    });
+
+    test('mine hit stops kart and grants invulnerability', () => {
+        const scene = { add: jest.fn(), remove: jest.fn() };
+        const kart = new Kart(0xff0000, scene);
+        window.gameEngine = { karts: [kart] };
+        const mine = new Mine(kart.position.clone(), scene);
+        mine.owner = {};
+        mine.checkCollisions();
+        expect(kart.isInvulnerable).toBe(true);
+        expect(kart.invulnerabilityTime).toBe(3);
+        expect(kart.velocity.length()).toBe(0);
+        expect(mine.active).toBe(false);
     });
 });


### PR DESCRIPTION
## Summary
- add `applyProjectileHit` method to Kart for projectiles
- call `applyProjectileHit` from Missile/Mine collisions
- test missile and mine hits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b456a856483238434ca84b37bba04