### PR TITLE
Implement timed powerup respawns

### DIFF
--- a/src/js/Powerup.js
+++ b/src/js/Powerup.js
@@ -57,11 +57,17 @@ class Powerup {
     
     checkCollision(kart) {
         if (this.collected) return false;
-        
+
         const distance = kart.position.distanceTo(this.position);
         if (distance < 2) {
             this.collected = true;
             this.scene.remove(this.mesh);
+            setTimeout(() => {
+                this.collected = false;
+                if (!(typeof global !== 'undefined' && global.NO_GRAPHICS)) {
+                    this.scene.add(this.mesh);
+                }
+            }, 1000);
             return true;
         }
         return false;

--- a/tests/Kart.test.js
+++ b/tests/Kart.test.js
@@ -155,4 +155,21 @@ describe('Powerup', () => {
         const result = powerup.checkCollision(kart)
         expect(result).toBe(false)
     })
+
+    test('respawns after collection', () => {
+        jest.useFakeTimers()
+        const prev = global.NO_GRAPHICS
+        global.NO_GRAPHICS = false
+        mockScene.add.mockClear()
+        const pu = new Powerup('boost', { x: 0, y: 0, z: 0 }, mockScene)
+        const addCalls = mockScene.add.mock.calls.length
+        const kart = { position: { distanceTo: jest.fn(() => 1) } }
+        pu.checkCollision(kart)
+        expect(pu.collected).toBe(true)
+        jest.advanceTimersByTime(1000)
+        expect(pu.collected).toBe(false)
+        expect(mockScene.add.mock.calls.length).toBe(addCalls + 1)
+        global.NO_GRAPHICS = prev
+        jest.useRealTimers()
+    })
 })


### PR DESCRIPTION
## Summary
- respawn powerups one second after being picked up
- test powerup respawn timing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b4af6a9f48323a3557dd2261791b0