### PR TITLE
Extend projectile stun duration

### DIFF
--- a/src/js/Kart.js
+++ b/src/js/Kart.js
@@ -231,6 +231,8 @@ class Kart extends THREE.Group {
         if (this.isInvulnerable) return
         this.velocity.set(0, 0, 0)
         this.acceleration.set(0, 0, 0)
+        this.isStopped = true
+        this.stopTime = 1
         this.isInvulnerable = true
         this.invulnerabilityTime = 3
         if (typeof global === 'undefined' || !global.NO_GRAPHICS) {

--- a/tests/Missile.test.js
+++ b/tests/Missile.test.js
@@ -22,6 +22,8 @@ describe('Projectile hits', () => {
         missile.owner = {};
         missile.checkCollisions();
         expect(kart.isInvulnerable).toBe(true);
+        expect(kart.isStopped).toBe(true);
+        expect(kart.stopTime).toBe(1);
         expect(kart.invulnerabilityTime).toBe(3);
         expect(kart.velocity.length()).toBe(0);
         expect(missile.active).toBe(false);
@@ -35,6 +37,8 @@ describe('Projectile hits', () => {
         mine.owner = {};
         mine.checkCollisions();
         expect(kart.isInvulnerable).toBe(true);
+        expect(kart.isStopped).toBe(true);
+        expect(kart.stopTime).toBe(1);
         expect(kart.invulnerabilityTime).toBe(3);
         expect(kart.velocity.length()).toBe(0);
         expect(mine.active).toBe(false);


### PR DESCRIPTION
## Summary
- stop karts for 1s when struck by a missile or mine
- test that missiles and mines apply the stun

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b965430a083239af174236e6238b8