### PR TITLE
Add simple track editor

### DIFF
--- a/editor.html
+++ b/editor.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Track Editor</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 0;
+            padding: 0;
+        }
+        #toolbar {
+            padding: 10px;
+            background: #333;
+            color: #fff;
+        }
+        #editorCanvas {
+            border: 1px solid #000;
+            display: block;
+        }
+        #exportArea {
+            width: 100%;
+            height: 150px;
+        }
+        #propertyWindow {
+            position: absolute;
+            top: 10px;
+            right: 10px;
+            background: #fff;
+            padding: 10px;
+            border: 1px solid #000;
+        }
+        .hidden {
+            display: none;
+        }
+    </style>
+</head>
+<body>
+    <div id="toolbar">
+        <select id="trackSelect">
+            <option value="circuit">Circuit</option>
+            <option value="desert">Desert</option>
+            <option value="snow">Snow</option>
+        </select>
+        <button id="importBtn">Import</button>
+        <button id="exportBtn">Export</button>
+        <button id="copyBtn">Copy</button>
+    </div>
+    <canvas id="editorCanvas" width="800" height="600"></canvas>
+    <textarea id="exportArea" placeholder="Exported JSON"></textarea>
+    <div id="propertyWindow" class="hidden">
+        <div>
+            <label>X: <input id="prop_x" type="number"></label>
+        </div>
+        <div>
+            <label>Y: <input id="prop_y" type="number"></label>
+        </div>
+        <div>
+            <label>Z: <input id="prop_z" type="number"></label>
+        </div>
+        <div>
+            <label>Width: <input id="prop_width" type="number"></label>
+        </div>
+        <div>
+            <label>Height: <input id="prop_height" type="number"></label>
+        </div>
+        <div>
+            <label>Depth: <input id="prop_depth" type="number"></label>
+        </div>
+        <div>
+            <label>Rotation: <input id="prop_rotation" type="number"></label>
+        </div>
+        <button id="applyBtn">Apply</button>
+    </div>
+    <script src="src/js/TrackEditor.js"></script>
+</body>
+</html>

--- a/src/js/TrackEditor.js
+++ b/src/js/TrackEditor.js
@@ -1,0 +1,113 @@
+const canvas = document.getElementById('editorCanvas')
+const ctx = canvas.getContext('2d')
+const trackSelect = document.getElementById('trackSelect')
+const importBtn = document.getElementById('importBtn')
+const exportBtn = document.getElementById('exportBtn')
+const copyBtn = document.getElementById('copyBtn')
+const exportArea = document.getElementById('exportArea')
+const propertyWindow = document.getElementById('propertyWindow')
+const applyBtn = document.getElementById('applyBtn')
+
+let trackData = null
+let scale = 5
+let selectedObstacle = null
+
+function worldToCanvas(x, z) {
+    return {
+        x: canvas.width / 2 + x * scale,
+        y: canvas.height / 2 + z * scale
+    }
+}
+
+function draw() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height)
+    if (!trackData) return
+    ctx.fillStyle = '#444'
+    ctx.fillRect(0, 0, canvas.width, canvas.height)
+    ctx.fillStyle = '#888'
+    trackData.obstacles.forEach(obs => {
+        const pos = worldToCanvas(obs.x, obs.z)
+        const w = obs.width * scale
+        const h = obs.depth * scale
+        ctx.save()
+        ctx.translate(pos.x, pos.y)
+        ctx.rotate((obs.rotation || 0) * Math.PI / 180)
+        ctx.fillStyle = 'red'
+        ctx.fillRect(-w / 2, -h / 2, w, h)
+        ctx.restore()
+    })
+}
+
+function getClickedObstacle(mx, my) {
+    if (!trackData) return null
+    for (let i = trackData.obstacles.length - 1; i >= 0; i--) {
+        const obs = trackData.obstacles[i]
+        const pos = worldToCanvas(obs.x, obs.z)
+        const w = obs.width * scale
+        const h = obs.depth * scale
+        const angle = (obs.rotation || 0) * Math.PI / 180
+        const dx = mx - pos.x
+        const dy = my - pos.y
+        const tx = Math.cos(-angle) * dx - Math.sin(-angle) * dy
+        const ty = Math.sin(-angle) * dx + Math.cos(-angle) * dy
+        if (Math.abs(tx) <= w / 2 && Math.abs(ty) <= h / 2) {
+            return { obs, index: i }
+        }
+    }
+    return null
+}
+
+canvas.addEventListener('wheel', e => {
+    e.preventDefault()
+    scale *= e.deltaY < 0 ? 1.1 : 0.9
+    draw()
+})
+
+canvas.addEventListener('click', e => {
+    if (!trackData) return
+    const rect = canvas.getBoundingClientRect()
+    const mx = e.clientX - rect.left
+    const my = e.clientY - rect.top
+    const result = getClickedObstacle(mx, my)
+    if (result) {
+        selectedObstacle = result
+        propertyWindow.classList.remove('hidden')
+        propertyWindow.dataset.index = result.index
+        ;['x','y','z','width','height','depth','rotation'].forEach(key => {
+            const input = document.getElementById('prop_' + key)
+            input.value = result.obs[key] || 0
+        })
+    } else {
+        propertyWindow.classList.add('hidden')
+    }
+})
+
+applyBtn.addEventListener('click', () => {
+    if (!selectedObstacle) return
+    const obs = trackData.obstacles[selectedObstacle.index]
+    ;['x','y','z','width','height','depth','rotation'].forEach(key => {
+        const input = document.getElementById('prop_' + key)
+        obs[key] = parseFloat(input.value)
+    })
+    propertyWindow.classList.add('hidden')
+    draw()
+})
+
+importBtn.addEventListener('click', async () => {
+    const track = trackSelect.value
+    const res = await fetch(`src/tracks/${track}.json`)
+    trackData = await res.json()
+    draw()
+})
+
+exportBtn.addEventListener('click', () => {
+    if (!trackData) return
+    exportArea.value = JSON.stringify(trackData, null, 2)
+})
+
+copyBtn.addEventListener('click', () => {
+    exportArea.select()
+    document.execCommand('copy')
+})
+
+draw()


### PR DESCRIPTION
## Summary
- build a barebones 2D track editor
- allow importing existing tracks and editing obstacle properties
- exporting JSON and copying to clipboard
- show track on a zoomable canvas

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm test --silent -- --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_687b9935eb288323a13bc145a7bc4368