### PR TITLE
Disallow picking up new powerup when already holding one

### DIFF
--- a/src/js/Track.js
+++ b/src/js/Track.js
@@ -175,6 +175,8 @@ class Track {
     }
     
     checkPowerupCollisions(kart) {
+        if (kart.currentPowerup) return;
+
         this.powerups.forEach(powerup => {
             if (powerup.checkCollision(kart)) {
                 kart.collectPowerup(powerup.type);

--- a/tests/Track.test.js
+++ b/tests/Track.test.js
@@ -60,4 +60,21 @@ describe('Track obstacle rotation', () => {
 
         expect(collided).toBe(true);
     });
+});
+
+describe('Track powerup handling', () => {
+    test('kart does not pick up new powerup if already holding one', () => {
+        const scene = { add: jest.fn(), remove: jest.fn() }
+        const track = new Track('test', scene)
+        const powerup = { checkCollision: jest.fn(() => true), type: 'boost' }
+        track.powerups = [powerup]
+
+        const kart = new Kart(0xff0000, scene)
+        kart.currentPowerup = 'missile'
+
+        track.checkPowerupCollisions(kart)
+
+        expect(powerup.checkCollision).not.toHaveBeenCalled()
+        expect(kart.currentPowerup).toBe('missile')
+    })
 })


### PR DESCRIPTION
## Summary
- prevent karts from collecting a powerup if one is already active
- test that a kart can't grab another powerup while it still has one

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c0c83cd388323b818e52853d8cc60