### PR TITLE
Fix kart elevation to prevent skipping obstacles

### DIFF
--- a/src/js/GameEngine.js
+++ b/src/js/GameEngine.js
@@ -144,6 +144,7 @@ class GameEngine {
             const startPos = startPositions[i] || startPositions[0];
             kart.position.copy(startPos); // Use start position from track data
             kart.position.y += 1; // Raise kart slightly above ground
+            kart.groundY = kart.position.y
 
             // Face towards the next checkpoint from the start position
             const direction = new THREE.Vector3().subVectors(firstCheckpoint, startPos).normalize();

--- a/src/js/Kart.js
+++ b/src/js/Kart.js
@@ -39,6 +39,7 @@ class Kart extends THREE.Group {
         this.isAI = false;
         this.aiController = null;
         this.currentTrack = null;
+        this.groundY = this.position.y;
         
         if (!(typeof global !== 'undefined' && global.NO_GRAPHICS)) {
             this.createMesh();
@@ -138,6 +139,7 @@ class Kart extends THREE.Group {
         }
         
         this.position.add(this.velocity.clone().multiplyScalar(deltaTime));
+        this.position.y = this.groundY;
         const turnScale = 2;
         const turnAngle = this.angularVelocity * deltaTime * turnScale;
         this.rotation.y += turnAngle;

--- a/src/js/Track.js
+++ b/src/js/Track.js
@@ -271,11 +271,16 @@ class Track {
             const mtv = this.checkSATCollision(kart.body, obstacle);
             if (mtv) {
                 collided = true;
-                kart.position.sub(mtv);
-                const relativeVelocity = kart.velocity.clone(); 
-                const normal = mtv.clone().normalize();
-                const impulse = normal.multiplyScalar(relativeVelocity.dot(normal) * -1.1);
-                kart.velocity.add(impulse);
+                const horizontalMtv = mtv.clone();
+                horizontalMtv.y = 0;
+                kart.position.sub(horizontalMtv);
+                kart.position.y = kart.groundY;
+                const relativeVelocity = kart.velocity.clone();
+                const normal = horizontalMtv.clone().normalize();
+                if (normal.length() > 0) {
+                    const impulse = normal.multiplyScalar(relativeVelocity.dot(normal) * -1.1);
+                    kart.velocity.add(impulse);
+                }
                 kart.velocity.multiplyScalar(0.9); // Apply friction after collision
             }
         });


### PR DESCRIPTION
## Summary
- keep kart position locked to `groundY`
- ignore vertical displacement when resolving obstacle collisions
- record ground level for each kart when starting a race

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c8ad484fc832399b63d58fd45ee47