### PR TITLE
Add autoplay restart when race ends

### DIFF
--- a/src/js/GameEngine.js
+++ b/src/js/GameEngine.js
@@ -123,6 +123,9 @@ class GameEngine {
         await AIController.preloadBrain(this.currentTrack.type)
         this.gameStarted = false
         this.clearKarts()
+        if (this.currentTrack && typeof this.currentTrack.reset === 'function') {
+            this.currentTrack.reset()
+        }
         this.isAutoplay = true
         this.setupRace(true)
         this.camera.position.set(0, 60, 0)

--- a/src/js/GameEngine.js
+++ b/src/js/GameEngine.js
@@ -37,6 +37,7 @@ class GameEngine {
         this.uiUpdateInterval = 100; // milliseconds
         this.lastUiUpdateTime = 0;
         this.racePathElements = []; // To store references to path lines and arrows
+        this.restartingAutoplay = false;
 
         if (typeof window !== 'undefined') {
             window.gameEngine = this
@@ -365,11 +366,17 @@ class GameEngine {
     }
 
     checkAutoplayRestart() {
-        if (!this.isAutoplay) return
+        if (!this.isAutoplay || this.restartingAutoplay) return
         const finished = this.karts.length > 0 && this.karts.every(k => k.currentLap > 3)
         if (finished) {
+            this.restartingAutoplay = true
             this.stop()
-            this.startAutoplay()
+            const result = this.startAutoplay()
+            if (result && typeof result.then === 'function') {
+                result.finally(() => { this.restartingAutoplay = false })
+            } else {
+                this.restartingAutoplay = false
+            }
         }
     }
 

--- a/src/js/GameEngine.js
+++ b/src/js/GameEngine.js
@@ -238,6 +238,8 @@ class GameEngine {
             this.updateUI();
             this.lastUiUpdateTime = currentTime;
         }
+
+        this.checkAutoplayRestart()
     }
     
     updateCamera() {
@@ -357,6 +359,15 @@ class GameEngine {
             this.scene.remove(element);
         });
         this.racePathElements = [];
+    }
+
+    checkAutoplayRestart() {
+        if (!this.isAutoplay) return
+        const finished = this.karts.length > 0 && this.karts.every(k => k.currentLap > 3)
+        if (finished) {
+            this.stop()
+            this.startAutoplay()
+        }
     }
 
     drawRacePath() {

--- a/src/js/Track.js
+++ b/src/js/Track.js
@@ -134,6 +134,28 @@ class Track {
         return this.startPositions;
     }
 
+    reset() {
+        if (DEBUG_Track) console.log('Track: Resetting dynamic objects.');
+        this.powerups.forEach(p => {
+            if (p.mesh && p.scene) this.scene.remove(p.mesh)
+        })
+        this.powerups = []
+        this.missiles.forEach(m => {
+            if (m.mesh) this.scene.remove(m.mesh)
+        })
+        this.missiles = []
+        this.mines.forEach(m => {
+            if (m.mesh) this.scene.remove(m.mesh)
+        })
+        this.mines = []
+        this.explosions.forEach(e => {
+            if (e.mesh) this.scene.remove(e.mesh)
+        })
+        this.explosions = []
+        this.checkpoints.forEach(cp => { cp.passed = false })
+        this.createPowerups()
+    }
+
     createCheckpointLabel(number) {
         const size = 64;
         const canvas = document.createElement('canvas');

--- a/tests/GameEngine.test.js
+++ b/tests/GameEngine.test.js
@@ -20,3 +20,18 @@ describe('GameEngine checkpoint marker', () => {
         expect(engine.checkpointMarker.position.z).toBe(0)
     })
 })
+
+describe('GameEngine autoplay', () => {
+    test('restarts when all karts finished', () => {
+        const engine = new GameEngine()
+        engine.isAutoplay = true
+        engine.startAutoplay = jest.fn()
+        engine.karts = [
+            { currentLap: 4 },
+            { currentLap: 4 }
+        ]
+
+        engine.checkAutoplayRestart()
+        expect(engine.startAutoplay).toHaveBeenCalled()
+    })
+})

--- a/tests/GameEngine.test.js
+++ b/tests/GameEngine.test.js
@@ -24,10 +24,10 @@ describe('GameEngine checkpoint marker', () => {
 })
 
 describe('GameEngine autoplay', () => {
-    test('restarts when all karts finished', () => {
+    test('restarts when all karts finished', async () => {
         const engine = new GameEngine()
         engine.isAutoplay = true
-        engine.startAutoplay = jest.fn()
+        engine.startAutoplay = jest.fn(() => Promise.resolve())
         engine.karts = [
             { currentLap: 4 },
             { currentLap: 4 }
@@ -35,6 +35,22 @@ describe('GameEngine autoplay', () => {
 
         engine.checkAutoplayRestart()
         expect(engine.startAutoplay).toHaveBeenCalled()
+        await Promise.resolve()
+        expect(engine.restartingAutoplay).toBe(false)
+    })
+
+    test('does not restart multiple times while pending', () => {
+        const engine = new GameEngine()
+        engine.isAutoplay = true
+        engine.startAutoplay = jest.fn(() => Promise.resolve())
+        engine.karts = [
+            { currentLap: 4 },
+            { currentLap: 4 }
+        ]
+
+        engine.checkAutoplayRestart()
+        engine.checkAutoplayRestart()
+        expect(engine.startAutoplay).toHaveBeenCalledTimes(1)
     })
 
     test('startAutoplay resets current track', async () => {

--- a/tests/GameEngine.test.js
+++ b/tests/GameEngine.test.js
@@ -1,5 +1,7 @@
 global.AudioManager = class AudioManager {}
+global.AIController = require('../src/js/AIController').AIController
 const { GameEngine } = require('../src/js/GameEngine')
+const { AIController } = require('../src/js/AIController')
 
 describe('GameEngine checkpoint marker', () => {
     test('updateCheckpointMarker positions marker over next checkpoint', () => {
@@ -33,5 +35,16 @@ describe('GameEngine autoplay', () => {
 
         engine.checkAutoplayRestart()
         expect(engine.startAutoplay).toHaveBeenCalled()
+    })
+
+    test('startAutoplay resets current track', async () => {
+        const engine = new GameEngine()
+        const track = { reset: jest.fn(), getStartPositions: () => [], checkpoints: [ { position: new THREE.Vector3() } ] }
+        engine.currentTrack = track
+        AIController.preloadBrain = jest.fn(() => Promise.resolve())
+        engine.setupRace = jest.fn()
+        engine.start = jest.fn()
+        await engine.startAutoplay()
+        expect(track.reset).toHaveBeenCalled()
     })
 })


### PR DESCRIPTION
## Summary
- automatically restart autoplay when all karts complete three laps
- test autoplay restarting logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c9ab74ca88323b048e26d10cfe3d0