### PR TITLE
Fix kart speed after autoplay

### DIFF
--- a/src/js/GameEngine.js
+++ b/src/js/GameEngine.js
@@ -181,6 +181,7 @@ class GameEngine {
     
     start() {
         if (DEBUG_GameEngine) console.log('GameEngine: Starting animation loop.');
+        this.clock.start();
         this.isRunning = true;
         this.animate();
     }


### PR DESCRIPTION
## Summary
- reset the THREE.Clock when starting a race to avoid leftover delta time from the autoplay demo

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ca84421c88323b77f097e360e4c10