### PR TITLE
Fix autoplay slowdown from overlapping frames

### DIFF
--- a/src/js/GameEngine.js
+++ b/src/js/GameEngine.js
@@ -33,6 +33,8 @@ class GameEngine {
             lastTime: 0
         }
 
+        this.animationId = null
+
         this.checkpointMarker = null
         this.uiUpdateInterval = 100; // milliseconds
         this.lastUiUpdateTime = 0;
@@ -188,6 +190,12 @@ class GameEngine {
     stop() {
         if (DEBUG_GameEngine) console.log('GameEngine: Stopping animation loop.');
         this.isRunning = false;
+        if (this.animationId !== null) {
+            if (typeof cancelAnimationFrame !== 'undefined') {
+                cancelAnimationFrame(this.animationId)
+            }
+            this.animationId = null
+        }
     }
 
     clearKarts() {
@@ -204,7 +212,7 @@ class GameEngine {
         if (DEBUG_GameEngine) console.log('GameEngine: Animating frame.');
         if (!this.isRunning) return;
         
-        requestAnimationFrame(() => this.animate());
+        this.animationId = requestAnimationFrame(() => this.animate());
         
         const deltaTime = this.clock.getDelta();
         this.update(deltaTime);

--- a/tests/GameEngine.test.js
+++ b/tests/GameEngine.test.js
@@ -34,4 +34,35 @@ describe('GameEngine autoplay', () => {
         engine.checkAutoplayRestart()
         expect(engine.startAutoplay).toHaveBeenCalled()
     })
+
+    test('stop cancels animation frame', () => {
+        const engine = new GameEngine()
+        const mockRAF = jest.fn(() => 42)
+        const mockCancel = jest.fn()
+        global.requestAnimationFrame = mockRAF
+        global.cancelAnimationFrame = mockCancel
+
+        engine.currentTrack = {
+            update: jest.fn(),
+            checkObstacleCollisions: jest.fn(),
+            checkPowerupCollisions: jest.fn(),
+            checkpoints: [{ position: new THREE.Vector3() }]
+        }
+        engine.karts = [{
+            position: new THREE.Vector3(),
+            quaternion: new THREE.Quaternion(),
+            isPlayer: true,
+            nextCheckpoint: 0,
+            update: jest.fn()
+        }]
+
+        engine.start()
+        engine.stop()
+
+        expect(mockRAF).toHaveBeenCalledTimes(1)
+        expect(mockCancel).toHaveBeenCalledWith(42)
+
+        delete global.requestAnimationFrame
+        delete global.cancelAnimationFrame
+    })
 })


### PR DESCRIPTION
## Summary
- prevent multiple animation loops by storing the requestAnimationFrame id
- cancel the frame when stopping the game
- test that stop cancels the scheduled animation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cb2e3af948323a690f30b30c748e3