### PR TITLE
Ensure obstacle data loaded in headless mode

### DIFF
--- a/src/js/Kart.js
+++ b/src/js/Kart.js
@@ -41,8 +41,9 @@ class Kart extends THREE.Group {
         this.currentTrack = null;
         this.groundY = this.position.y;
         
+        this.createMesh();
+
         if (!(typeof global !== 'undefined' && global.NO_GRAPHICS)) {
-            this.createMesh();
             this.addToScene();
         }
     }

--- a/src/js/Track.js
+++ b/src/js/Track.js
@@ -52,22 +52,26 @@ class Track {
             ground.rotation.x = -Math.PI / 2;
             ground.receiveShadow = true;
             this.scene.add(ground);
+        }
 
-            obstacles.forEach(obstacleData => {
-                if (obstacleData.type === 'barrier') {
-                    const barrierGeometry = new THREE.BoxGeometry(obstacleData.width, obstacleData.height, obstacleData.depth);
-                    const barrierMaterial = new THREE.MeshLambertMaterial({ color: parseInt(trackGeometry.borderColor) });
-                    const barrier = new THREE.Mesh(barrierGeometry, barrierMaterial);
-                    barrier.position.set(obstacleData.x, obstacleData.y, obstacleData.z);
-                    if (typeof obstacleData.rotation !== 'undefined') {
-                        barrier.rotation.y = THREE.MathUtils.degToRad(obstacleData.rotation);
-                    }
-                    barrier.castShadow = true;
-                    this.scene.add(barrier);
-                    this.obstacles.push(barrier);
+        obstacles.forEach(obstacleData => {
+            if (obstacleData.type === 'barrier') {
+                const barrierGeometry = new THREE.BoxGeometry(obstacleData.width, obstacleData.height, obstacleData.depth);
+                const barrierMaterial = new THREE.MeshLambertMaterial({ color: parseInt(trackGeometry.borderColor) });
+                const barrier = new THREE.Mesh(barrierGeometry, barrierMaterial);
+                barrier.position.set(obstacleData.x, obstacleData.y, obstacleData.z);
+                if (typeof obstacleData.rotation !== 'undefined') {
+                    barrier.rotation.y = THREE.MathUtils.degToRad(obstacleData.rotation);
                 }
-            });
+                barrier.castShadow = true;
+                if (typeof global === 'undefined' || !global.NO_GRAPHICS) {
+                    this.scene.add(barrier);
+                }
+                this.obstacles.push(barrier);
+            }
+        });
 
+        if (typeof global === 'undefined' || !global.NO_GRAPHICS) {
             decorations.forEach(decorationData => {
                 if (decorationData.type === 'marking') {
                     const markingGeometry = new THREE.PlaneGeometry(decorationData.width, decorationData.depth);

--- a/tests/Track.test.js
+++ b/tests/Track.test.js
@@ -60,6 +60,23 @@ describe('Track obstacle rotation', () => {
 
         expect(collided).toBe(true);
     });
+
+    test('obstacles are created without graphics', () => {
+        const scene = { add: jest.fn(), remove: jest.fn() }
+        const track = new Track('test', scene)
+        track.trackData = {
+            trackGeometry: { width: 100, height: 100, borderColor: '0xff0000', roadColor: '0x333333' },
+            environment: { skyColor: '0x000000', groundColor: '0x000000', ambientLight: '0x000000', directionalLight: '0x000000' },
+            obstacles: [
+                { type: 'barrier', x: 0, y: 0, z: 0, width: 10, height: 2, depth: 1 }
+            ],
+            decorations: []
+        }
+        global.NO_GRAPHICS = true
+        track.createTrack()
+        expect(track.obstacles.length).toBe(1)
+        expect(scene.add).not.toHaveBeenCalled()
+    })
 });
 
 describe('Track powerup handling', () => {


### PR DESCRIPTION
## Summary
- keep obstacle objects even without graphics
- skip drawing barriers when `NO_GRAPHICS` is true
- add regression test for obstacle creation in headless mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cbc332c648323ab5d60be5146b460