### PR TITLE
Fix training when all karts disqualify

### DIFF
--- a/src/training/cli.js
+++ b/src/training/cli.js
@@ -115,7 +115,7 @@ class TrainingEnvironment {
             
             const hasQualified = await this.evaluatePopulation()
             if (!hasQualified) {
-                console.log('All karts disqualified. Skipping to next generation.')
+                console.log('All karts disqualified. Using top performers for next generation.')
                 this.evolvePopulation()
                 continue
             }
@@ -215,7 +215,8 @@ class TrainingEnvironment {
 
                 if (this.track.checkObstacleCollisions(kart)) {
                     disqualified = true
-                    fitness = 0
+                    fitness -= 50
+                    if (fitness < 0) fitness = 0
                     break
                 }
                 


### PR DESCRIPTION
## Summary
- preserve partial fitness when karts crash during training
- mention that disqualified generations still evolve from the best performers

## Testing
- `npm test` *(fails: command not found)*
- `npm run train 1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cc0c98b30832397b8386043670916