### PR TITLE
Move fitness logic to AIController

### DIFF
--- a/src/js/AIController.js
+++ b/src/js/AIController.js
@@ -50,6 +50,7 @@ class AIController {
         this.timeElapsed = 0;
         this.lastLap = 0;
         this.timeSinceLastCheckpoint = 0;
+        this.finishBonusApplied = false;
         
         this.sensors = {
             forward: 0,
@@ -248,6 +249,11 @@ class AIController {
 
         this.fitness += currentFitness
 
+        if (this.kart.currentLap > 3 && !this.finishBonusApplied) {
+            this.fitness += 1000;
+            this.finishBonusApplied = true;
+        }
+
         this.lastProgress = progress;
         this.lastCheckpoint = this.kart.nextCheckpoint;
         this.lastLap = this.kart.currentLap
@@ -263,6 +269,14 @@ class AIController {
         } else {
             this.stuckTimer = 0;
         }
+    }
+
+    checkObstacleCollision() {
+        const collided = this.track.checkObstacleCollisions(this.kart);
+        if (collided) {
+            this.fitness -= 500;
+        }
+        return collided;
     }
     
     copy() {

--- a/src/training/cli.js
+++ b/src/training/cli.js
@@ -206,9 +206,8 @@ class TrainingEnvironment {
                 kart.updatePhysics(deltaTime)
                 kart.updateProgress()
 
-                if (this.track.checkObstacleCollisions(kart)) {
+                if (ai.checkObstacleCollision()) {
                     disqualified = true
-                    ai.fitness -= 500
                     break
                 }
 
@@ -220,7 +219,6 @@ class TrainingEnvironment {
                 }
 
                 if (kart.currentLap > 3) {
-                    ai.fitness += 1000; // Bonus for finishing all laps
                     break;
                 }
 


### PR DESCRIPTION
## Summary
- handle obstacle and finish bonuses inside `AIController`
- call `ai.checkObstacleCollision()` in training CLI

## Testing
- `npm test`
- `npm run train 1`


------
https://chatgpt.com/codex/tasks/task_e_687ce4409f5c83239aa696126f9d9fb9