### PR TITLE
Fix kart disqualification in CLI training

### DIFF
--- a/src/training/cli.js
+++ b/src/training/cli.js
@@ -220,11 +220,22 @@ class TrainingEnvironment {
             const maxTime = 60
             const deltaTime = 0.016
             let disqualified = false
+            let stoppedTime = 0
             
             while (time < maxTime && kart.currentLap <= 2 && !disqualified) {
                 ai.update(deltaTime, [])
                 kart.updatePhysics(deltaTime)
                 kart.updateProgress()
+
+                if (kart.velocity.length() < 0.1) {
+                    stoppedTime += deltaTime
+                    if (stoppedTime > 2) {
+                        disqualified = true
+                        break
+                    }
+                } else {
+                    stoppedTime = 0
+                }
 
                 if (ai.checkObstacleCollision()) {
                     disqualified = true

--- a/tests/TrainingEnvironment.test.js
+++ b/tests/TrainingEnvironment.test.js
@@ -1,0 +1,14 @@
+const { TrainingEnvironment } = require('../src/training/cli.js')
+
+describe('TrainingEnvironment disqualification', () => {
+    test('disqualifies karts that stop moving', async () => {
+        const env = new TrainingEnvironment('circuit')
+        const network = {
+            forward: () => [0, 0, 0],
+            copy() { return this },
+            serialize() { return '{}' }
+        }
+        const result = await env.simulateRace(network)
+        expect(result.disqualified).toBe(true)
+    })
+})


### PR DESCRIPTION
## Summary
- disqualify karts that remain stopped during CLI-based training
- test that training disqualifies a stuck kart

## Testing
- `npm test`
- `npm run train 1`


------
https://chatgpt.com/codex/tasks/task_e_687ceafb2ccc8323aa40324f29f4ff3b