### PR TITLE
Tune training settings

### DIFF
--- a/src/js/AIController.js
+++ b/src/js/AIController.js
@@ -250,7 +250,7 @@ class AIController {
         this.fitness += currentFitness
 
         if (this.kart.currentLap > 3 && !this.finishBonusApplied) {
-            this.fitness += 1000;
+            this.fitness += 2000;
             this.finishBonusApplied = true;
         }
 

--- a/src/training/cli.js
+++ b/src/training/cli.js
@@ -67,11 +67,11 @@ class TrainingEnvironment {
         this.trackType = trackType;
         this.populationSize = 100;
         this.generations = parseInt(process.argv[2]) || 50;
-        this.mutationRate = 0.1
-        this.minMutationRate = 0.05
-        this.maxMutationRate = 0.5
+        this.mutationRate = 0.2
+        this.minMutationRate = 0.1
+        this.maxMutationRate = 0.7
         this.eliteCount = 5;
-        this.newBloodRate = 0.1
+        this.newBloodRate = 0.2
         this.prevBestFitness = 0;
         this.noImprovement = 0;
 
@@ -217,12 +217,12 @@ class TrainingEnvironment {
             
             ai.fitness = 0
             let time = 0
-            const maxTime = 60
+            const maxTime = 120
             const deltaTime = 0.016
             let disqualified = false
             let stoppedTime = 0
             
-            while (time < maxTime && kart.currentLap <= 2 && !disqualified) {
+            while (time < maxTime && kart.currentLap <= 5 && !disqualified) {
                 ai.update(deltaTime, [])
                 kart.updatePhysics(deltaTime)
                 kart.updateProgress()
@@ -249,7 +249,7 @@ class TrainingEnvironment {
                     console.log(`Time: ${time.toFixed(2)}, Kart Pos: (${kart.position.x.toFixed(2)}, ${kart.position.z.toFixed(2)}), Progress: ${kart.progress.toFixed(2)}, Next CP: ${kart.nextCheckpoint}, Current Lap: ${kart.currentLap}, Total Fitness: ${ai.fitness.toFixed(2)}`);
                 }
 
-                if (kart.currentLap > 3) {
+                if (kart.currentLap > 5) {
                     break;
                 }
 


### PR DESCRIPTION
## Summary
- bump mutation/new blood rates
- allow longer training and more laps
- increase finish bonus for training models

## Testing
- `npm test`
- `npm run train 1`
- `npm run train 10`

------
https://chatgpt.com/codex/tasks/task_e_687cedd7dc208323ad8b334bb760fe09