### PR TITLE
Clear mines when autoplay restarts

### DIFF
--- a/src/js/GameEngine.js
+++ b/src/js/GameEngine.js
@@ -125,6 +125,8 @@ class GameEngine {
         await AIController.preloadBrain(this.currentTrack.type)
         this.gameStarted = false
         this.clearKarts()
+        this.clearMines()
+        this.clearMissiles()
         this.isAutoplay = true
         this.setupRace(true)
         this.camera.position.set(0, 60, 0)
@@ -206,6 +208,28 @@ class GameEngine {
             }
         })
         this.karts = []
+    }
+
+    clearMines() {
+        if (!this.currentTrack || !this.currentTrack.mines) return
+        this.currentTrack.mines.forEach(mine => {
+            if (mine.mesh && mine.scene) {
+                mine.scene.remove(mine.mesh)
+            }
+            mine.active = false
+        })
+        this.currentTrack.mines = []
+    }
+
+    clearMissiles() {
+        if (!this.currentTrack || !this.currentTrack.missiles) return
+        this.currentTrack.missiles.forEach(missile => {
+            if (missile.mesh && missile.scene) {
+                missile.scene.remove(missile.mesh)
+            }
+            missile.active = false
+        })
+        this.currentTrack.missiles = []
     }
     
     animate() {

--- a/tests/GameEngine.test.js
+++ b/tests/GameEngine.test.js
@@ -35,6 +35,33 @@ describe('GameEngine autoplay', () => {
         expect(engine.startAutoplay).toHaveBeenCalled()
     })
 
+    test('startAutoplay clears mines and missiles', async () => {
+        class DummyAIController {
+            static preloadBrain() { return Promise.resolve() }
+        }
+        global.AIController = DummyAIController
+        const { Kart } = require('../src/js/Kart')
+        const { Mine, Missile } = require('../src/js/Powerup')
+        global.Kart = Kart
+        const engine = new GameEngine()
+        const track = {
+            type: 'test',
+            mines: [new Mine(new THREE.Vector3(), engine.scene, {}), new Mine(new THREE.Vector3(), engine.scene, {})],
+            missiles: [new Missile(new THREE.Vector3(), 0, engine.scene, {}), new Missile(new THREE.Vector3(), 0, engine.scene, {})],
+            getStartPositions: () => [new THREE.Vector3(0, 0, 0)],
+            checkpoints: [{ position: new THREE.Vector3() }]
+        }
+        engine.currentTrack = track
+        engine.start = jest.fn()
+
+        await engine.startAutoplay()
+
+        expect(track.mines.length).toBe(0)
+        expect(track.missiles.length).toBe(0)
+        delete global.Kart
+        delete global.AIController
+    })
+
     test('stop cancels animation frame', () => {
         const engine = new GameEngine()
         const mockRAF = jest.fn(() => 42)


### PR DESCRIPTION
## Summary
- clear missiles when restarting autoplay alongside mines
- test clearing of missiles on autoplay restart

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d513a83f483239e9dbc5ee1ab2c0a