### PR TITLE
Clear mines when autoplay restarts

### DIFF
--- a/src/js/GameEngine.js
+++ b/src/js/GameEngine.js
@@ -125,6 +125,7 @@ class GameEngine {
         await AIController.preloadBrain(this.currentTrack.type)
         this.gameStarted = false
         this.clearKarts()
+        this.clearMines()
         this.isAutoplay = true
         this.setupRace(true)
         this.camera.position.set(0, 60, 0)
@@ -206,6 +207,17 @@ class GameEngine {
             }
         })
         this.karts = []
+    }
+
+    clearMines() {
+        if (!this.currentTrack || !this.currentTrack.mines) return
+        this.currentTrack.mines.forEach(mine => {
+            if (mine.mesh && mine.scene) {
+                mine.scene.remove(mine.mesh)
+            }
+            mine.active = false
+        })
+        this.currentTrack.mines = []
     }
     
     animate() {

--- a/tests/GameEngine.test.js
+++ b/tests/GameEngine.test.js
@@ -35,6 +35,31 @@ describe('GameEngine autoplay', () => {
         expect(engine.startAutoplay).toHaveBeenCalled()
     })
 
+    test('startAutoplay clears mines', async () => {
+        class DummyAIController {
+            static preloadBrain() { return Promise.resolve() }
+        }
+        global.AIController = DummyAIController
+        const { Kart } = require('../src/js/Kart')
+        const { Mine } = require('../src/js/Powerup')
+        global.Kart = Kart
+        const engine = new GameEngine()
+        const track = {
+            type: 'test',
+            mines: [new Mine(new THREE.Vector3(), engine.scene, {}), new Mine(new THREE.Vector3(), engine.scene, {})],
+            getStartPositions: () => [new THREE.Vector3(0, 0, 0)],
+            checkpoints: [{ position: new THREE.Vector3() }]
+        }
+        engine.currentTrack = track
+        engine.start = jest.fn()
+
+        await engine.startAutoplay()
+
+        expect(track.mines.length).toBe(0)
+        delete global.Kart
+        delete global.AIController
+    })
+
     test('stop cancels animation frame', () => {
         const engine = new GameEngine()
         const mockRAF = jest.fn(() => 42)


### PR DESCRIPTION
## Summary
- clear mines before restarting autoplay
- add test for mine clearing on autoplay restart

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d513a83f483239e9dbc5ee1ab2c0a