### PR TITLE
Add countdown before game start

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,6 +88,17 @@
         .hidden {
             display: none !important;
         }
+
+        #countdown {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            font-size: 72px;
+            color: white;
+            z-index: 1001;
+            pointer-events: none;
+        }
     </style>
 </head>
 <body>
@@ -99,7 +110,9 @@
             <p>It's a me, a racist stereotype!</p>
             <p>Click to start</p>
         </div>
-        
+
+        <div id="countdown" class="hidden"></div>
+
         <div id="stats" class="hidden">
             <div>FPS: <span id="fps">0</span></div>
             <div>Position: <span id="position">1st</span></div>

--- a/src/js/GameEngine.js
+++ b/src/js/GameEngine.js
@@ -114,6 +114,7 @@ class GameEngine {
         document.getElementById('stats').classList.remove('hidden')
 
         await this.audioManager.init()
+        await this.showCountdown()
         this.setupRace()
         this.clearRacePath()
         this.drawRacePath()
@@ -130,6 +131,19 @@ class GameEngine {
         this.camera.position.set(0, 60, 0)
         this.camera.lookAt(new THREE.Vector3(0, 0, 0))
         this.start()
+    }
+
+    async showCountdown(seconds = 3) {
+        const countdownEl = document.getElementById('countdown')
+        if (!countdownEl) return
+        countdownEl.classList.remove('hidden')
+        for (let i = seconds; i > 0; i--) {
+            countdownEl.textContent = String(i)
+            await new Promise(r => setTimeout(r, 1000))
+        }
+        countdownEl.textContent = 'GO!'
+        await new Promise(r => setTimeout(r, 1000))
+        countdownEl.classList.add('hidden')
     }
     
     setupRace(autoplay = false) {

--- a/tests/GameEngine.test.js
+++ b/tests/GameEngine.test.js
@@ -66,3 +66,32 @@ describe('GameEngine autoplay', () => {
         delete global.cancelAnimationFrame
     })
 })
+
+describe('GameEngine countdown', () => {
+    test('showCountdown updates element and hides it', async () => {
+        jest.useFakeTimers()
+        const engine = new GameEngine()
+        const addSpy = jest.fn()
+        const removeSpy = jest.fn()
+        const originalGet = global.document.getElementById
+        const countdownEl = { classList: { add: addSpy, remove: removeSpy }, textContent: '' }
+        jest.spyOn(global.document, 'getElementById').mockImplementation(id => {
+            if (id === 'countdown') {
+                return countdownEl
+            }
+            return originalGet(id)
+        })
+
+        const el = global.document.getElementById('countdown')
+        const promise = engine.showCountdown(1)
+        await jest.runAllTimersAsync()
+        await promise
+
+        expect(removeSpy).toHaveBeenCalledWith('hidden')
+        expect(addSpy).toHaveBeenCalledWith('hidden')
+        expect(el.textContent).toBe('GO!')
+
+        jest.useRealTimers()
+        global.document.getElementById.mockRestore()
+    })
+})

--- a/tests/setup.js
+++ b/tests/setup.js
@@ -42,6 +42,7 @@ global.document = {
         const elements = {
             startScreen: { classList: { add: () => {}, remove: () => {} } },
             stats: { classList: { add: () => {}, remove: () => {} } },
+            countdown: { classList: { add: () => {}, remove: () => {} }, textContent: '' },
             fps: { textContent: '' },
             position: { textContent: '' },
             lap: { textContent: '' },


### PR DESCRIPTION
## Summary
- add countdown overlay UI element
- implement GameEngine.showCountdown and call from startGame
- update tests to cover countdown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d52e920b8832386aa9b96d56d36d0