### PR TITLE
Add continue flag for training CLI

### DIFF
--- a/src/training/cli.js
+++ b/src/training/cli.js
@@ -162,6 +162,7 @@ class TrainingEnvironment {
                 try {
                     const data = JSON.parse(fs.readFileSync(bestPath, 'utf8'))
                     const network = NeuralNetwork.deserialize(JSON.parse(data.network))
+                    this.bestFitness = parseFloat(data.fitness)
                     this.population.push({
                         network,
                         fitness: 0,


### PR DESCRIPTION
## Summary
- allow TrainingEnvironment to accept a `continue` flag
- if flag is provided load `<track>_best.json` and insert into the initial population
- parse the new argument in the CLI entry point

## Testing
- `npm run train 1`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e7ee9c8ac83238acfed6127f874ec