### PR TITLE
Hide checkpoint marker during autoplay

### DIFF
--- a/src/js/GameEngine.js
+++ b/src/js/GameEngine.js
@@ -248,12 +248,15 @@ class GameEngine {
 
         if (this.checkpointMarker) {
             this.scene.remove(this.checkpointMarker)
+            this.checkpointMarker = null
         }
-        const markerGeometry = new THREE.SphereGeometry(1, 16, 16)
-        const markerMaterial = new THREE.MeshBasicMaterial({ color: 0xff0000 })
-        this.checkpointMarker = new THREE.Mesh(markerGeometry, markerMaterial)
-        this.scene.add(this.checkpointMarker)
-        this.updateCheckpointMarker()
+        if (!autoplay) {
+            const markerGeometry = new THREE.SphereGeometry(1, 16, 16)
+            const markerMaterial = new THREE.MeshBasicMaterial({ color: 0xff0000 })
+            this.checkpointMarker = new THREE.Mesh(markerGeometry, markerMaterial)
+            this.scene.add(this.checkpointMarker)
+            this.updateCheckpointMarker()
+        }
 
         if (autoplay) {
             this.camera.position.set(0, 60, 0)

--- a/tests/GameEngine.test.js
+++ b/tests/GameEngine.test.js
@@ -68,6 +68,31 @@ describe('GameEngine autoplay', () => {
         delete global.AIController
     })
 
+    test('checkpoint marker hidden during autoplay', async () => {
+        class DummyAIController {
+            static preloadBrain() { return Promise.resolve() }
+        }
+        global.AIController = DummyAIController
+        const { Kart } = require('../src/js/Kart')
+        global.Kart = Kart
+        const engine = new GameEngine()
+        const track = {
+            type: 'test',
+            mines: [],
+            missiles: [],
+            getStartPositions: () => [new THREE.Vector3(0, 0, 0)],
+            checkpoints: [{ position: new THREE.Vector3() }]
+        }
+        engine.currentTrack = track
+        engine.start = jest.fn()
+
+        await engine.startAutoplay()
+
+        expect(engine.checkpointMarker).toBeNull()
+        delete global.Kart
+        delete global.AIController
+    })
+
     test('stop cancels animation frame', () => {
         const engine = new GameEngine()
         const mockRAF = jest.fn(() => 42)


### PR DESCRIPTION
## Summary
- don't create the next checkpoint marker in autoplay
- test that the marker is null during autoplay

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f32e2bcd08323bc6766ad8b87feb9