### PR TITLE
Add cactus decoration support

### DIFF
--- a/src/js/Track.js
+++ b/src/js/Track.js
@@ -107,6 +107,13 @@ class Track {
                     marking.rotation.x = -Math.PI / 2;
                     marking.position.set(decorationData.x, decorationData.y, decorationData.z);
                     this.trackGroup.add(marking);
+                } else if (decorationData.type === 'cactus') {
+                    const cactusGeometry = new THREE.CylinderGeometry(decorationData.radius, decorationData.radius, decorationData.height, 6);
+                    const cactusMaterial = new THREE.MeshLambertMaterial({ color: 0x228b22 });
+                    const cactus = new THREE.Mesh(cactusGeometry, cactusMaterial);
+                    cactus.position.set(decorationData.x, decorationData.y, decorationData.z);
+                    cactus.castShadow = true;
+                    this.trackGroup.add(cactus);
                 }
             });
         }

--- a/tests/Track.test.js
+++ b/tests/Track.test.js
@@ -103,3 +103,23 @@ describe('Track powerup handling', () => {
         expect(kart.currentPowerup).toBe('missile')
     })
 })
+
+describe('Track decorations', () => {
+    test('cactus decoration is added to trackGroup', () => {
+        const scene = { add: jest.fn(), remove: jest.fn() }
+        const track = new Track('test', scene)
+        track.trackData = {
+            trackGeometry: { width: 100, height: 100, borderColor: '0xff0000', roadColor: '0x333333' },
+            environment: { skyColor: '0x000000', groundColor: '0x000000', ambientLight: '0x000000', directionalLight: '0x000000' },
+            obstacles: [],
+            decorations: [
+                { type: 'cactus', x: 0, y: 1.5, z: 0, height: 3, radius: 0.5 }
+            ]
+        }
+        global.NO_GRAPHICS = false
+        track.createTrack()
+        global.NO_GRAPHICS = true
+        const hasCactus = track.trackGroup.children.some(obj => obj.geometry instanceof THREE.CylinderGeometry)
+        expect(hasCactus).toBe(true)
+    })
+})


### PR DESCRIPTION
## Summary
- add new `cactus` decoration option in `Track`
- test cactus decoration creation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f473b20088323808d8d57158ffa46