### PR TITLE
Support decoration rotation

### DIFF
--- a/src/js/Track.js
+++ b/src/js/Track.js
@@ -101,19 +101,25 @@ class Track {
         if (typeof global === 'undefined' || !global.NO_GRAPHICS) {
             decorations.forEach(decorationData => {
                 if (decorationData.type === 'marking') {
-                    const markingGeometry = new THREE.PlaneGeometry(decorationData.width, decorationData.depth);
-                    const markingMaterial = new THREE.MeshLambertMaterial({ color: parseInt(decorationData.color) });
-                    const marking = new THREE.Mesh(markingGeometry, markingMaterial);
-                    marking.rotation.x = -Math.PI / 2;
-                    marking.position.set(decorationData.x, decorationData.y, decorationData.z);
-                    this.trackGroup.add(marking);
+                    const markingGeometry = new THREE.PlaneGeometry(decorationData.width, decorationData.depth)
+                    const markingMaterial = new THREE.MeshLambertMaterial({ color: parseInt(decorationData.color) })
+                    const marking = new THREE.Mesh(markingGeometry, markingMaterial)
+                    marking.rotation.x = -Math.PI / 2
+                    if (typeof decorationData.rotation !== 'undefined') {
+                        marking.rotation.y = THREE.MathUtils.degToRad(decorationData.rotation)
+                    }
+                    marking.position.set(decorationData.x, decorationData.y, decorationData.z)
+                    this.trackGroup.add(marking)
                 } else if (decorationData.type === 'cactus') {
-                    const cactusGeometry = new THREE.CylinderGeometry(decorationData.radius, decorationData.radius, decorationData.height, 6);
-                    const cactusMaterial = new THREE.MeshLambertMaterial({ color: 0x228b22 });
-                    const cactus = new THREE.Mesh(cactusGeometry, cactusMaterial);
-                    cactus.position.set(decorationData.x, decorationData.y, decorationData.z);
-                    cactus.castShadow = true;
-                    this.trackGroup.add(cactus);
+                    const cactusGeometry = new THREE.CylinderGeometry(decorationData.radius, decorationData.radius, decorationData.height, 6)
+                    const cactusMaterial = new THREE.MeshLambertMaterial({ color: 0x228b22 })
+                    const cactus = new THREE.Mesh(cactusGeometry, cactusMaterial)
+                    cactus.position.set(decorationData.x, decorationData.y, decorationData.z)
+                    if (typeof decorationData.rotation !== 'undefined') {
+                        cactus.rotation.y = THREE.MathUtils.degToRad(decorationData.rotation)
+                    }
+                    cactus.castShadow = true
+                    this.trackGroup.add(cactus)
                 }
             });
         }

--- a/src/tracks/desert.json
+++ b/src/tracks/desert.json
@@ -283,7 +283,8 @@
       "y": 1.5,
       "z": -20,
       "height": 3,
-      "radius": 0.5
+      "radius": 0.5,
+      "rotation": 90
     },
     {
       "type": "cactus",
@@ -291,7 +292,8 @@
       "y": 1.5,
       "z": 10,
       "height": 2.5,
-      "radius": 0.4
+      "radius": 0.4,
+      "rotation": -30
     },
     {
       "type": "cactus",
@@ -299,7 +301,8 @@
       "y": 1.5,
       "z": 30,
       "height": 3.5,
-      "radius": 0.6
+      "radius": 0.6,
+      "rotation": 45
     },
     {
       "type": "cactus",
@@ -307,7 +310,8 @@
       "y": 1.5,
       "z": -25,
       "height": 2.8,
-      "radius": 0.45
+      "radius": 0.45,
+      "rotation": 0
     },
     {
       "type": "rock",

--- a/tests/Track.test.js
+++ b/tests/Track.test.js
@@ -122,4 +122,22 @@ describe('Track decorations', () => {
         const hasCactus = track.trackGroup.children.some(obj => obj.geometry instanceof THREE.CylinderGeometry)
         expect(hasCactus).toBe(true)
     })
+
+    test('rotation value is applied to cactus decoration', () => {
+        const scene = { add: jest.fn(), remove: jest.fn() }
+        const track = new Track('test', scene)
+        track.trackData = {
+            trackGeometry: { width: 100, height: 100, borderColor: '0xff0000', roadColor: '0x333333' },
+            environment: { skyColor: '0x000000', groundColor: '0x000000', ambientLight: '0x000000', directionalLight: '0x000000' },
+            obstacles: [],
+            decorations: [
+                { type: 'cactus', x: 0, y: 1.5, z: 0, height: 3, radius: 0.5, rotation: 90 }
+            ]
+        }
+        global.NO_GRAPHICS = false
+        track.createTrack()
+        global.NO_GRAPHICS = true
+        const cactus = track.trackGroup.children.find(obj => obj.geometry instanceof THREE.CylinderGeometry)
+        expect(cactus.rotation.y).toBeCloseTo(Math.PI / 2)
+    })
 })


### PR DESCRIPTION
## Summary
- allow decorations to specify rotation
- document decoration rotation in desert track file
- test decoration rotation is applied

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f48f2c4888323882b49992fdfb151