### PR TITLE
Add rock decoration

### DIFF
--- a/src/js/Track.js
+++ b/src/js/Track.js
@@ -120,6 +120,16 @@ class Track {
                     }
                     cactus.castShadow = true
                     this.trackGroup.add(cactus)
+                } else if (decorationData.type === 'rock') {
+                    const rockGeometry = new THREE.BoxGeometry(decorationData.width, decorationData.height, decorationData.depth)
+                    const rockMaterial = new THREE.MeshLambertMaterial({ color: 0x808080 })
+                    const rock = new THREE.Mesh(rockGeometry, rockMaterial)
+                    rock.position.set(decorationData.x, decorationData.y, decorationData.z)
+                    if (typeof decorationData.rotation !== 'undefined') {
+                        rock.rotation.y = THREE.MathUtils.degToRad(decorationData.rotation)
+                    }
+                    rock.castShadow = true
+                    this.trackGroup.add(rock)
                 }
             });
         }

--- a/tests/Track.test.js
+++ b/tests/Track.test.js
@@ -140,4 +140,40 @@ describe('Track decorations', () => {
         const cactus = track.trackGroup.children.find(obj => obj.geometry instanceof THREE.CylinderGeometry)
         expect(cactus.rotation.y).toBeCloseTo(Math.PI / 2)
     })
+
+    test('rock decoration is added to trackGroup', () => {
+        const scene = { add: jest.fn(), remove: jest.fn() }
+        const track = new Track('test', scene)
+        track.trackData = {
+            trackGeometry: { width: 100, height: 100, borderColor: '0xff0000', roadColor: '0x333333' },
+            environment: { skyColor: '0x000000', groundColor: '0x000000', ambientLight: '0x000000', directionalLight: '0x000000' },
+            obstacles: [],
+            decorations: [
+                { type: 'rock', x: 0, y: 0.5, z: 0, width: 2, height: 1, depth: 2 }
+            ]
+        }
+        global.NO_GRAPHICS = false
+        track.createTrack()
+        global.NO_GRAPHICS = true
+        const hasRock = track.trackGroup.children.some(obj => obj.geometry instanceof THREE.BoxGeometry)
+        expect(hasRock).toBe(true)
+    })
+
+    test('rotation value is applied to rock decoration', () => {
+        const scene = { add: jest.fn(), remove: jest.fn() }
+        const track = new Track('test', scene)
+        track.trackData = {
+            trackGeometry: { width: 100, height: 100, borderColor: '0xff0000', roadColor: '0x333333' },
+            environment: { skyColor: '0x000000', groundColor: '0x000000', ambientLight: '0x000000', directionalLight: '0x000000' },
+            obstacles: [],
+            decorations: [
+                { type: 'rock', x: 0, y: 0.5, z: 0, width: 2, height: 1, depth: 2, rotation: 45 }
+            ]
+        }
+        global.NO_GRAPHICS = false
+        track.createTrack()
+        global.NO_GRAPHICS = true
+        const rock = track.trackGroup.children.find(obj => obj.geometry instanceof THREE.BoxGeometry)
+        expect(rock.rotation.y).toBeCloseTo(Math.PI / 4)
+    })
 })


### PR DESCRIPTION
## Summary
- add new `rock` decoration type in `Track`
- test rock decoration creation and rotation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f4ec67ef083239edfadc81bdf6930