### PR TITLE
Add house decoration type

### DIFF
--- a/src/js/Track.js
+++ b/src/js/Track.js
@@ -178,21 +178,18 @@ class Track {
                     const baseGeometry = new THREE.BoxGeometry(decorationData.width, decorationData.height, decorationData.depth)
                     const baseMaterial = new THREE.MeshLambertMaterial({ color: 0x8b4513 })
                     const base = new THREE.Mesh(baseGeometry, baseMaterial)
+                    const decorationRotation = decorationData.rotation || 0
                     base.position.set(decorationData.x, decorationData.y + decorationData.height / 2, decorationData.z)
-                    if (typeof decorationData.rotation !== 'undefined') {
-                        base.rotation.y = THREE.MathUtils.degToRad(decorationData.rotation)
-                    }
+                    base.rotation.y = THREE.MathUtils.degToRad(decorationRotation)
                     base.castShadow = true
                     this.trackGroup.add(base)
 
-                    const roofRadius = Math.max(decorationData.width, decorationData.depth) / 2
+                    const roofRadius = Math.max(decorationData.width, decorationData.depth)
                     const roofGeometry = new THREE.ConeGeometry(roofRadius, decorationData.roofHeight, 4)
                     const roofMaterial = new THREE.MeshLambertMaterial({ color: 0x8b0000 })
                     const roof = new THREE.Mesh(roofGeometry, roofMaterial)
                     roof.position.set(decorationData.x, decorationData.y + decorationData.height + decorationData.roofHeight / 2, decorationData.z)
-                    if (typeof decorationData.rotation !== 'undefined') {
-                        roof.rotation.y = THREE.MathUtils.degToRad(decorationData.rotation)
-                    }
+                    roof.rotation.y = THREE.MathUtils.degToRad(decorationRotation + 45)
                     roof.castShadow = true
                     this.trackGroup.add(roof)
                 }

--- a/src/js/Track.js
+++ b/src/js/Track.js
@@ -174,6 +174,27 @@ class Track {
                     }
                     icicle.castShadow = true
                     this.trackGroup.add(icicle)
+                } else if (decorationData.type === 'house') {
+                    const baseGeometry = new THREE.BoxGeometry(decorationData.width, decorationData.height, decorationData.depth)
+                    const baseMaterial = new THREE.MeshLambertMaterial({ color: 0x8b4513 })
+                    const base = new THREE.Mesh(baseGeometry, baseMaterial)
+                    base.position.set(decorationData.x, decorationData.y + decorationData.height / 2, decorationData.z)
+                    if (typeof decorationData.rotation !== 'undefined') {
+                        base.rotation.y = THREE.MathUtils.degToRad(decorationData.rotation)
+                    }
+                    base.castShadow = true
+                    this.trackGroup.add(base)
+
+                    const roofRadius = Math.max(decorationData.width, decorationData.depth) / 2
+                    const roofGeometry = new THREE.ConeGeometry(roofRadius, decorationData.roofHeight, 4)
+                    const roofMaterial = new THREE.MeshLambertMaterial({ color: 0x8b0000 })
+                    const roof = new THREE.Mesh(roofGeometry, roofMaterial)
+                    roof.position.set(decorationData.x, decorationData.y + decorationData.height + decorationData.roofHeight / 2, decorationData.z)
+                    if (typeof decorationData.rotation !== 'undefined') {
+                        roof.rotation.y = THREE.MathUtils.degToRad(decorationData.rotation)
+                    }
+                    roof.castShadow = true
+                    this.trackGroup.add(roof)
                 }
             });
         }

--- a/src/tracks/circuit.json
+++ b/src/tracks/circuit.json
@@ -64,6 +64,7 @@
     { "type": "barrier", "x": -11.843, "y": 1, "z": -28.597, "width": 26, "height": 2, "depth": 1, "rotation": 202.5 }
   ],
   "decorations": [
-    { "type": "marking", "x": -28, "y": 0.01, "z": -29, "width": 2, "height": 0.01, "depth": 10, "color": "0xffffff", "rotation": 45 }
+    { "type": "marking", "x": -28, "y": 0.01, "z": -29, "width": 2, "height": 0.01, "depth": 10, "color": "0xffffff", "rotation": 45 },
+    { "type": "house", "x": -25, "y": 0, "z": -28, "width": 4, "height": 3, "depth": 4, "roofHeight": 2 }
   ]
 }

--- a/src/tracks/circuit.json
+++ b/src/tracks/circuit.json
@@ -65,6 +65,6 @@
   ],
   "decorations": [
     { "type": "marking", "x": -28, "y": 0.01, "z": -29, "width": 2, "height": 0.01, "depth": 10, "color": "0xffffff", "rotation": 45 },
-    { "type": "house", "x": -25, "y": 0, "z": -28, "width": 4, "height": 3, "depth": 4, "roofHeight": 2 }
+    { "type": "house", "x": -20, "y": 0, "z": -20, "width": 5, "height": 4, "depth": 5, "roofHeight": 3, "rotation": 45 }
   ]
 }

--- a/tests/Track.test.js
+++ b/tests/Track.test.js
@@ -232,4 +232,24 @@ describe('Track decorations', () => {
         const hasCone = track.trackGroup.children.some(obj => obj.geometry instanceof THREE.ConeGeometry)
         expect(hasCone).toBe(true)
     })
+
+    test('house decoration is added to trackGroup', () => {
+        const scene = { add: jest.fn(), remove: jest.fn() }
+        const track = new Track('test', scene)
+        track.trackData = {
+            trackGeometry: { width: 100, height: 100, borderColor: '0xff0000', roadColor: '0x333333' },
+            environment: { skyColor: '0x000000', groundColor: '0x000000', ambientLight: '0x000000', directionalLight: '0x000000' },
+            obstacles: [],
+            decorations: [
+                { type: 'house', x: 0, y: 0, z: 0, width: 2, height: 2, depth: 2, roofHeight: 1 }
+            ]
+        }
+        global.NO_GRAPHICS = false
+        track.createTrack()
+        global.NO_GRAPHICS = true
+        const hasBox = track.trackGroup.children.some(obj => obj.geometry instanceof THREE.BoxGeometry)
+        const hasConeRoof = track.trackGroup.children.some(obj => obj.geometry instanceof THREE.ConeGeometry)
+        expect(hasBox).toBe(true)
+        expect(hasConeRoof).toBe(true)
+    })
 })


### PR DESCRIPTION
## Summary
- support new `house` decoration in `Track`
- add house decoration test
- place a house near the start area in `circuit.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687f5c48f1c483239b6659ada1eb83c0