### PR TITLE
Add future checkpoint angle sensor

### DIFF
--- a/src/js/AIController.js
+++ b/src/js/AIController.js
@@ -33,7 +33,7 @@ class AIController {
         this.track = track;
         this.trackName = trackName;
 
-        this.network = new NeuralNetwork(9, 12, 3); // Initialize with a random brain
+        this.network = new NeuralNetwork(10, 12, 3); // Initialize with a random brain
 
         if (!isTraining) {
             this.loadBrain().then(network => {
@@ -64,6 +64,7 @@ class AIController {
             checkpoint: 0,
             velocity: 0,
             angle: 0,
+            nextAngle: 0,
             powerup: 0
         };
     }
@@ -130,6 +131,13 @@ class AIController {
             this.sensors.checkpoint = nextCheckpoint.position.distanceTo(this.kart.position) / 50;
             const toCheckpoint = nextCheckpoint.position.clone().sub(this.kart.position).normalize();
             this.sensors.angle = forward.dot(toCheckpoint);
+
+            const afterNextIndex = (this.kart.nextCheckpoint + 1) % this.track.checkpoints.length;
+            const afterNext = this.track.checkpoints[afterNextIndex];
+            if (afterNext) {
+                const toAfterNext = afterNext.position.clone().sub(this.kart.position).normalize();
+                this.sensors.nextAngle = forward.dot(toAfterNext);
+            }
         }
         
         this.sensors.velocity = this.kart.velocity.length() / this.kart.maxSpeed;
@@ -169,6 +177,7 @@ class AIController {
             this.sensors.checkpoint,
             this.sensors.velocity,
             this.sensors.angle,
+            this.sensors.nextAngle,
             this.sensors.powerup
         ];
     }

--- a/src/training/cli.js
+++ b/src/training/cli.js
@@ -204,7 +204,7 @@ class TrainingEnvironment {
         }
 
         while (this.population.length < this.populationSize) {
-            const network = new NeuralNetwork(9, 12, 3)
+            const network = new NeuralNetwork(10, 12, 3)
             this.population.push({
                 network,
                 fitness: 0,
@@ -310,7 +310,7 @@ class TrainingEnvironment {
         while (newPopulation.length < this.populationSize) {
             if (Math.random() < this.newBloodRate) {
                 newPopulation.push({
-                    network: new NeuralNetwork(9, 12, 3),
+                    network: new NeuralNetwork(10, 12, 3),
                     fitness: 0,
                     isTraining: true
                 })

--- a/tests/AIController.test.js
+++ b/tests/AIController.test.js
@@ -1,0 +1,28 @@
+const { AIController } = require('../src/js/AIController')
+const { Kart } = require('../src/js/Kart')
+const { Track } = require('../src/js/Track')
+const { NeuralNetwork } = require('../src/js/NeuralNetwork')
+global.NeuralNetwork = NeuralNetwork
+
+describe('AIController sensors', () => {
+    test('nextAngle measures angle to checkpoint after next', () => {
+        const scene = { add: jest.fn(), remove: jest.fn() }
+        const audioManager = { playSound: jest.fn(), stopSound: jest.fn() }
+        const track = new Track('test', scene)
+        track.checkpoints = [
+            { position: new THREE.Vector3(0, 0, -10) },
+            { position: new THREE.Vector3(10, 0, -10) }
+        ]
+        track.obstacles = []
+        const kart = new Kart(0xff0000, scene, audioManager)
+        kart.position.set(0, 0, 0)
+        kart.nextCheckpoint = 0
+        kart.currentTrack = track
+        kart.quaternion.set(0, 0, 0, 1)
+
+        const ai = new AIController(kart, track, 'test', true)
+        ai.updateSensors([])
+        expect(ai.sensors.angle).toBeCloseTo(1)
+        expect(ai.sensors.nextAngle).toBeCloseTo(Math.SQRT1_2)
+    })
+})


### PR DESCRIPTION
## Summary
- add `nextAngle` sensor in AIController to look two checkpoints ahead
- adapt neural network input size to 10
- update training CLI to create neural networks with 10 inputs
- test `nextAngle` sensor calculation

## Testing
- `npm run train 1`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6883a67ed0748323b2224e61de345277